### PR TITLE
Fix the jquery id selector possibly breaking on special characters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.scandio</groupId>
     <artifactId>settings-framework</artifactId>
-    <version>0.5.2-SNAPSHOT</version>
+    <version>0.5.2-m01</version>
 
     <organization>
         <name>Scandio GmbH</name>
@@ -58,7 +58,7 @@
         <url>https://github.com/scandio/settings-framework</url>
         <connection>scm:git:git@github.com:scandio/settings-framework.git</connection>
         <developerConnection>scm:git:git@github.com:scandio/settings-framework.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>settings-framework-0.5.2-m01</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.scandio</groupId>
     <artifactId>settings-framework</artifactId>
-    <version>0.5.2-m01</version>
+    <version>0.5.2-m02-SNAPSHOT</version>
 
     <organization>
         <name>Scandio GmbH</name>
@@ -58,7 +58,7 @@
         <url>https://github.com/scandio/settings-framework</url>
         <connection>scm:git:git@github.com:scandio/settings-framework.git</connection>
         <developerConnection>scm:git:git@github.com:scandio/settings-framework.git</developerConnection>
-        <tag>settings-framework-0.5.2-m01</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/resources/settings-framework/js/settings.js
+++ b/src/main/resources/settings-framework/js/settings.js
@@ -38,9 +38,32 @@
         });
       };
 
+      var escapeSelector = $.escapeSelector || function (selector) {
+        // CSS string/identifier serialization
+        // https://drafts.csswg.org/cssom/#common-serializing-idioms
+        var rcssescape = /([\0-\x1f\x7f]|^-?\d)|^-$|[^\x80-\uFFFF\w-]/g;
+        var fcssescape = function (ch, asCodePoint) {
+          if (asCodePoint) {
+
+            // U+0000 NULL becomes U+FFFD REPLACEMENT CHARACTER
+            if (ch === "\0") {
+              return "\uFFFD";
+            }
+
+            // Control characters and (dependent upon position) numbers get escaped as code points
+            return ch.slice(0, -1) + "\\" + ch.charCodeAt(ch.length - 1).toString(16) + " ";
+          }
+
+          // Other potentially-special ASCII characters get backslash-escaped
+          return "\\" + ch;
+        };
+        return (selector + "").replace(rcssescape, fcssescape);
+      };
+
       var fillValuesIntoForm = function(values) {
         Object.keys(values).forEach(function(key) {
-          var $input = $('#' + key);
+          var id = escapeSelector(key);
+          var $input = $('#' + id);
           if ($input.is(':checkbox')) {
             if (values[key] === 'true') {
               $input.attr('checked', true);


### PR DESCRIPTION
(```escapeSelector()``` method copied from [jQuery 3.0](https://api.jquery.com/jQuery.escapeSelector/))

Issue was that ```$("#" + variable)``` would fail with an exception if ```variable``` contained characters that need to be escaped for jQuery.