### PR TITLE
Fix the checkbox-selector mapping only unchecked checkboxes

### DIFF
--- a/src/main/resources/settings-framework/js/settings.js
+++ b/src/main/resources/settings-framework/js/settings.js
@@ -95,7 +95,7 @@ var __SF__ = __SF__ || (function() {
             e.preventDefault();
 
             var newValues = $form.serializeArray()
-              .concat($('input:checkbox:not(:checked)').map(function() {
+              .concat($('input:checkbox').map(function() {
                 return {name: this.name, value: this.checked ? 'true' : 'false'};
               }).get())
               .reduce(function(obj, item) {


### PR DESCRIPTION
The selector $('input:checkbox:not(:checked)') only selected for unchecked checkboxes, meaning the mapping of a checked checkbox to a value of "true" was never actually executed.

Checked checkboxes would then send a value of "on" to the server, unless they had the html-attribute "value" set to "true", which apparently overrides the default "on"-value of checkboxes ¯\\\_(ツ)\_/¯